### PR TITLE
Fix tests to pass on Windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
-lib/.precomp/*
-.precomp/*
-t/tmp/
-rakudoc_cache/*
+.precomp/
+/t/tmp/
+/t/cache/
+rakudoc_cache/
 workspace.xml
 *.iml
 .idea/

--- a/lib/Pod/From/Cache.pm6
+++ b/lib/Pod/From/Cache.pm6
@@ -49,11 +49,16 @@ class Pod::From::Cache {
             );
         }
 
+    method path-for-fragment($fragment) {
+        ~ reduce {$^a.add($^b)}, $!doc-source.IO, | $*SPEC.splitdir($fragment);
+    }
+
     submethod TWEAK {
         # get the .ignore-cache contents, if it exists and add to a set.
-        if ( $!doc-source ~ '/.ignore-cache').IO.f {
-            for ($!doc-source ~ '/.ignore-cache').IO.lines {
-                $!ignore{ $!doc-source ~ '/' ~ .trim }++;
+	my $ignore = $!doc-source.IO.add('.ignore-cache');
+        if $ignore.f {
+            for $ignore.lines {
+                $!ignore{ self.path-for-fragment(.trim) }++;
             }
         }
         self.get-pods;

--- a/t/10-cache.t
+++ b/t/10-cache.t
@@ -1,14 +1,15 @@
 use Test;
 use File::Directory::Tree;
 
-constant CACHE = 't/cache';
-constant DOC = 't/doctest';
+constant CACHE = ~'t'.IO.add('cache');
+constant DOC = ~'t'.IO.add('doctest');
 
 use Pod::From::Cache;
 
 rmtree CACHE;
 my Pod::From::Cache $m;
 
+my $fn = 'simple.pod6';
 plan 5;
 
 lives-ok { $m .= new(:doc-source(DOC), :cache-path(CACHE)) }, "Instantiates with minimum parameters";
@@ -16,7 +17,7 @@ ok CACHE.IO.d, 'cache created';
 
 is-deeply $m.list-files , $m.sources, 'All source files are refreshed' ;
 
-my $pod = $m.pod( (DOC ~ '/simple.pod6' ) );
+my $pod = $m.pod( ~DOC.IO.add($fn) );
 like $pod[0].contents[0].name, /
     'TITLE'
 /, 'Found compiled Title';
@@ -24,15 +25,12 @@ like $pod[0].contents[0].contents[0].contents[0], /
     'Powerful cache'
     /, 'Found compiled Title value';
 
-diag 'Must run 20-refresh.t or copy t/simple.pod6 back to t/doctest/';
-my $fn = 'simple.pod6';
-(DOC ~ "/$fn").IO.copy: "t/$fn";
-(DOC ~ "/$fn").IO.spurt(:append, qq:to/END/ );
+diag "Must run 20-refresh.t or copy t/$fn back to t/doctest/";
+DOC.IO.add($fn).copy: 't'.IO.add($fn);
+DOC.IO.add($fn).spurt(:append, qq:to/END/ );
     =begin pod
 
     =head The Time is { now.DateTime.hh-mm-ss }
 
     =end pod
     END
-
-done-testing;

--- a/t/20-refresh.t
+++ b/t/20-refresh.t
@@ -3,8 +3,8 @@ use File::Directory::Tree;
 
 # This test must follow 10-cache.t
 
-constant CACHE = 't/cache';
-constant DOC = 't/doctest';
+constant CACHE = 't'.IO.add('cache');
+constant DOC = 't'.IO.add('doctest');
 
 use Pod::From::Cache;
 
@@ -15,20 +15,20 @@ plan 5;
 
 $m .= new(:doc-source(DOC), :cache-path(CACHE) );
 
-is-deeply $m.refreshed-pods, [ DOC ~ "/$fn" , ], 'Detected refreshed source';
+is-deeply $m.refreshed-pods, [ ~DOC.IO.add($fn) , ], 'Detected refreshed source';
 
-like $m.pod( DOC ~ "/$fn" )[1].contents[0].contents[0].contents , /
+like $m.pod( ~DOC.IO.add($fn) )[1].contents[0].contents[0].contents , /
     'The Time is'
     /, 'Found the extra information';
 
-throws-like { $m.pod(DOC ~ '/unknown-source.pod6') }, X::Pod::From::Cache::NoPodInCache, 'Unknown pod triggers error';
-throws-like { $m.pod(DOC ~ '/simple.pod') }, X::Pod::From::Cache::NoPodInCache, 'Mispelt source-name triggers error';
+throws-like { $m.pod(~DOC.IO.add('unknown-source.pod6')) }, X::Pod::From::Cache::NoPodInCache, 'Unknown pod triggers error';
+throws-like { $m.pod(~DOC.IO.add($fn.chop)) }, X::Pod::From::Cache::NoPodInCache, 'Mispelt source-name triggers error';
 
-my $rv = $m.pod(DOC ~ '/sub/simple.pod6');
+my $rv = $m.pod(~DOC.IO.add('sub').add($fn));
 ok $rv.WHAT ~~ Array , 'found same name in subdirectory';
 
 rmtree CACHE;
-"t/$fn".IO.copy: DOC ~ "/$fn";
-"t/$fn".IO.unlink;
+'t'.IO.add($fn).copy: DOC.IO.add($fn);
+'t'.IO.add($fn).unlink;
 
 done-testing;

--- a/t/60-ignore-file.t
+++ b/t/60-ignore-file.t
@@ -1,14 +1,14 @@
 use Test;
 use File::Directory::Tree;
 
-constant CACHE = 't/cache';
-constant DOC = 't/doctest';
+constant CACHE = ~'t'.IO.add('cache');
+constant DOC   = ~'t'.IO.add('doctest');
 
 use Pod::From::Cache;
 
 rmtree CACHE;
 
-my $fn = DOC ~ '/.ignore-cache';
+my $fn = ~DOC.IO.add('.ignore-cache');
 $fn.IO.spurt(q:to/IGNORE/);
     # a comment
     contexts.pod6
@@ -16,9 +16,10 @@ $fn.IO.spurt(q:to/IGNORE/);
 
 my Pod::From::Cache $m .= new( :doc-source( DOC ), :cache-path( CACHE ));
 my $h = $m.sources.SetHash;
-ok $h<t/doctest/community.pod6 t/doctest/operators.pod6 t/doctest/simple.pod6 t/doctest/sub/simple.pod6 >, 'contexts.pod6 is ignored';
 
-is $m.pod( DOC ~ '/contexts.pod6' ) , Nil, 'Ignored files get Nil returned';
+cmp-ok $h, 'eqv', <community.pod6 operators.pod6 simple.pod6 sub/simple.pod6>.map({$m.path-for-fragment: $_}).SetHash, 'contexts.pod6 is ignored';
+
+is $m.pod( ~DOC.IO.add('contexts.pod6') ) , Nil, 'Ignored files get Nil returned';
 
 $fn.IO.unlink;
 


### PR DESCRIPTION
Tests are identical, but use IO::Path functions to ensure separators
fit the OS.