### PR TITLE
Use standard Raku .rakudoc extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ use Pod::From::Cache;
 
 my $cache = Pod::From::Cache.new;
 # used the default values of
-# - :extensions = <pod pod6 p6 pm pm6 rakupod>
+# - :extensions = <rakudoc pod pod6 p6 pm pm6>
 # - :doc-source = 'docs',
 # - :cache-path = 'rakudoc_cache'
 

--- a/lib/Pod/From/Cache.pm6
+++ b/lib/Pod/From/Cache.pm6
@@ -40,7 +40,7 @@ class Pod::From::Cache {
     has SetHash $!ignore .= new;
 
     submethod BUILD(
-        :@!extensions = <pod pod6 p6 pm pm6 rakupod>,
+        :@!extensions = <rakudoc pod pod6 p6 pm pm6>,
         :$!doc-source = 'docs',
         :$!cache-path = 'rakudoc_cache' # trans OS default directory name ,
         ) {


### PR DESCRIPTION
The Raku language specifies .rakudoc as the extension for files
containing documentation:

https://github.com/Raku/problem-solving/blob/master/solutions/language/Path-to-Raku.md#extensions